### PR TITLE
Correct typo

### DIFF
--- a/src/modules/currency-select/currency-select.constants.js
+++ b/src/modules/currency-select/currency-select.constants.js
@@ -7,7 +7,7 @@ export const HEADER_CURRENCY_VALUES = {
   GVT: "Genesis Vision",
   XRP: "Ripple",
   BCH: "Bitcoin Cash",
-  LTC: "Littlecoin",
+  LTC: "Litecoin",
   DOGE: "Dogecoin"
 };
 


### PR DESCRIPTION
`Littlecoin` ➜ `Litecoin`